### PR TITLE
feat: Additional Variable Types

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -506,8 +506,8 @@ variable "rulesets" {
   }
 
   validation {
-    condition     = alltrue([for k, v in var.rulesets : contains(["disabled", "active"], v.enforcement)])
-    error_message = "Ruleset enforcement must be disabled or active"
+    condition     = alltrue([for k, v in var.rulesets : contains(["disabled", "active", "evaluate"], v.enforcement)])
+    error_message = "Ruleset enforcement must be disabled, active, or evaluate"
   }
 
   validation {


### PR DESCRIPTION
## what
- added evaluate enforcement type

> [enforcement](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_ruleset#enforcement-1) - (Required) (String) Possible values for Enforcement are disabled, active, evaluate. Note: evaluate is currently only supported for owners of type organization.

## why
- Came across these awhile initially deploying the module. These are supported by the provider

## references
- 