### PR TITLE
Fix Teams Order of Operations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -178,6 +178,10 @@ resource "github_repository_environment" "default" {
       custom_branch_policies = !deployment_branch_policy.value.protected_branches
     }
   }
+
+  depends_on = [
+    github_repository_collaborators.default
+  ]
 }
 
 locals {


### PR DESCRIPTION
## what
- Add dependency on repository collaborators resource

## why
- The teams must be created for the repositories before creating environment protections rules that require reviewers (teams)

## references
```bash
│ Error: PUT https://api.github.com/repos/acme/my-bar-app/environments/prod: 422 Failed to create or update the environment protection rule. Required reviewers must have at least one reviewer to set prevent_self_review. []
│
│   with module.repository.github_repository_environment.default["prod"],
│   on .terraform/modules/repository/main.tf line 158, in resource "github_repository_environment" "default":
│  158: resource "github_repository_environment" "default" {
│
╵

```