### PR TITLE
deprecate: mark has_downloads variable as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Here is an example of using this module:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.9.0 |
 
 ## Providers
@@ -178,7 +178,7 @@ Here is an example of using this module:
 | <a name="input_fork"></a> [fork](#input\_fork) | Configuration for forking an existing repository | <pre>object({<br/>    source_owner = string<br/>    source_repo  = string<br/>  })</pre> | `null` | no |
 | <a name="input_gitignore_template"></a> [gitignore\_template](#input\_gitignore\_template) | Gitignore template | `string` | `null` | no |
 | <a name="input_has_discussions"></a> [has\_discussions](#input\_has\_discussions) | Whether the repository has discussions enabled | `bool` | `false` | no |
-| <a name="input_has_downloads"></a> [has\_downloads](#input\_has\_downloads) | Whether the repository has downloads enabled | `bool` | `false` | no |
+| <a name="input_has_downloads"></a> [has\_downloads](#input\_has\_downloads) | (DEPRECATED) Whether the repository has downloads enabled. This attribute is deprecated by GitHub and will be removed in a future version of this module. | `bool` | `false` | no |
 | <a name="input_has_issues"></a> [has\_issues](#input\_has\_issues) | Whether the repository has issues enabled | `bool` | `false` | no |
 | <a name="input_has_projects"></a> [has\_projects](#input\_has\_projects) | Whether the repository has projects enabled | `bool` | `false` | no |
 | <a name="input_has_wiki"></a> [has\_wiki](#input\_has\_wiki) | Whether the repository has wiki enabled | `bool` | `false` | no |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -7,7 +7,6 @@ has_issues                              = true
 has_discussions                         = true
 has_projects                            = true
 has_wiki                                = true
-has_downloads                           = true
 is_template                             = true
 allow_merge_commit                      = true
 merge_commit_title                      = "MERGE_MESSAGE"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -19,7 +19,6 @@ module "example" {
   is_template = var.is_template
 
   has_discussions = var.has_discussions
-  has_downloads   = var.has_downloads
   has_issues      = var.has_issues
   has_projects    = var.has_projects
   has_wiki        = var.has_wiki

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -75,12 +75,6 @@ variable "has_wiki" {
   default     = false
 }
 
-variable "has_downloads" {
-  description = "(DEPRECATED) Whether the repository has downloads enabled. This attribute is deprecated by GitHub and will be removed in a future version of this module."
-  type        = bool
-  default     = false
-}
-
 variable "is_template" {
   description = "Whether the repository is a template"
   type        = bool

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -76,7 +76,7 @@ variable "has_wiki" {
 }
 
 variable "has_downloads" {
-  description = "Whether the repository has downloads enabled"
+  description = "(DEPRECATED) Whether the repository has downloads enabled. This attribute is deprecated by GitHub and will be removed in a future version of this module."
   type        = bool
   default     = false
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     github = {

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -18,7 +18,6 @@ module "example" {
   is_template = var.is_template
 
   has_discussions = var.has_discussions
-  has_downloads   = var.has_downloads
   has_issues      = var.has_issues
   has_projects    = var.has_projects
   has_wiki        = var.has_wiki

--- a/examples/minimum/variables.tf
+++ b/examples/minimum/variables.tf
@@ -67,7 +67,7 @@ variable "has_wiki" {
 }
 
 variable "has_downloads" {
-  description = "Whether the repository has downloads enabled"
+  description = "(DEPRECATED) Whether the repository has downloads enabled. This attribute is deprecated by GitHub and will be removed in a future version of this module."
   type        = bool
   default     = false
 }

--- a/examples/minimum/variables.tf
+++ b/examples/minimum/variables.tf
@@ -66,12 +66,6 @@ variable "has_wiki" {
   default     = false
 }
 
-variable "has_downloads" {
-  description = "(DEPRECATED) Whether the repository has downloads enabled. This attribute is deprecated by GitHub and will be removed in a future version of this module."
-  type        = bool
-  default     = false
-}
-
 variable "is_template" {
   description = "Whether the repository is a template"
   type        = bool

--- a/examples/minimum/versions.tf
+++ b/examples/minimum/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     github = {

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,6 @@ resource "github_repository" "default" {
   is_template = var.is_template
 
   has_discussions = var.has_discussions
-  has_downloads   = var.has_downloads
   has_issues      = var.has_issues
   has_projects    = var.has_projects
   has_wiki        = var.has_wiki
@@ -594,4 +593,11 @@ resource "github_repository_ruleset" "default" {
   depends_on = [
     github_repository_environment.default
   ]
+}
+
+check "has_downloads_deprecation" {
+  assert {
+    condition     = var.has_downloads == false
+    error_message = "DEPRECATION WARNING: The 'has_downloads' variable is deprecated. GitHub has removed this feature and this variable will be removed in a future version of this module. Please remove 'has_downloads' from your configuration."
+  }
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -76,7 +76,6 @@ func TestExamplesComplete(t *testing.T) {
   assert.Equal(t, true, repo.GetHasProjects())
   assert.Equal(t, true, repo.GetHasDiscussions())
   assert.Equal(t, true, repo.GetHasWiki())
-  assert.Equal(t, true, repo.GetHasDownloads())
   assert.Equal(t, true, repo.GetIsTemplate())
   assert.Equal(t, true, repo.GetAllowSquashMerge())
   assert.Equal(t, "COMMIT_OR_PR_TITLE", repo.GetSquashMergeCommitTitle())

--- a/variables.tf
+++ b/variables.tf
@@ -71,7 +71,7 @@ variable "has_wiki" {
 }
 
 variable "has_downloads" {
-  description = "Whether the repository has downloads enabled"
+  description = "(DEPRECATED) Whether the repository has downloads enabled. This attribute is deprecated by GitHub and will be removed in a future version of this module."
   type        = bool
   default     = false
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
 
   required_providers {
     github = {


### PR DESCRIPTION
## what

- Deprecate `has_downloads` variable with backward-compatible warning instead of breaking removal
- Add `check` block to emit deprecation warning when users set `has_downloads = true`
- Remove `has_downloads` attribute from `github_repository` resource
- Bump minimum Terraform version to `>= 1.5` (required for check blocks)

## why

- The `has_downloads` attribute is officially deprecated in the GitHub Terraform provider (v6.10.2) and will be removed in a future version
- Rather than breaking existing configurations by removing the variable, this approach warns users to update their code
- Terraform 1.5+ is required to use `check` blocks which enable warnings without errors

## references

- [GitHub Provider Documentation - has_downloads deprecation](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository#has_downloads)
- [GitHub Community Discussion on Downloads Feature Removal](https://github.com/orgs/community/discussions/102145#discussioncomment-8351756)