### PR TITLE
fix: add missing field for autolink reference

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,6 +137,7 @@ resource "github_repository_autolink_reference" "default" {
   key_prefix = each.value.key_prefix
 
   target_url_template = each.value.target_url_template
+  is_alphanumeric     = each.value.is_alphanumeric
 }
 
 


### PR DESCRIPTION
## what

Adding missing variable field to the autolink references.

## why

`is_alphanumeric` field exists in `autolink_references` variable, but is not added in the `github_repository_autolink_reference` resource. Because of that, default provider's value is used (`true`) regardless of the value specified by the variable.

