### PR TITLE
fix: pass variable as a name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "github_repository" "default" {
   count = module.this.enabled ? 1 : 0
 
-  name        = module.this.id
+  name        = var.name
   description = var.description
   visibility  = var.visibility
 


### PR DESCRIPTION
## what

Passing variable `name` instead of null-label normalized ID.

## why

Normalized null-label ID doesn't allow IDs including dot character. Effectively,  it tries to change repository name like `.github` -> `github`.
