### PR TITLE
feat: webhook secret support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -304,7 +304,7 @@ locals {
   variables   = module.this.enabled ? var.variables : {}
   secrets     = module.this.enabled ? { for k, v in nonsensitive(var.secrets) : k => sensitive(v) } : {}
   deploy_keys = module.this.enabled ? var.deploy_keys : {}
-  webhooks    = module.this.enabled ? var.webhooks : {}
+  webhooks    = module.this.enabled ? { for k, v in nonsensitive(var.webhooks) : k => v } : {}
   labels      = module.this.enabled ? var.labels : {}
   rulesets    = module.this.enabled ? var.rulesets : {}
 }

--- a/main.tf
+++ b/main.tf
@@ -304,7 +304,7 @@ locals {
   variables   = module.this.enabled ? var.variables : {}
   secrets     = module.this.enabled ? { for k, v in nonsensitive(var.secrets) : k => sensitive(v) } : {}
   deploy_keys = module.this.enabled ? var.deploy_keys : {}
-  webhooks    = module.this.enabled ? { for k, v in nonsensitive(var.webhooks) : k => v } : {}
+  webhooks    = module.this.enabled ? { for k, v in nonsensitive(var.webhooks) : k => sensitive(v) } : {}
   labels      = module.this.enabled ? var.labels : {}
   rulesets    = module.this.enabled ? var.rulesets : {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -371,8 +371,9 @@ variable "webhooks" {
     insecure_ssl = optional(bool, false)
     secret       = optional(string, null)
   }))
-  default  = {}
-  nullable = false
+  default   = {}
+  sensitive = true
+  nullable  = false
 
   validation {
     condition     = alltrue([for k, v in var.webhooks : can(regex("^http(s)?://", v.url))])


### PR DESCRIPTION
## what

Handling webhook secret as a sensitive value.

## why

Webhook secret is a sensitive value, so it should be treated in a similar manner to the repository secrets.